### PR TITLE
fix: reprojection not using correct api

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ See https://github.com/ben-lc/export-geopackage/blob/feat/add-documentation/gpkg
 
 | identifier | string | identifier of geopackage content | false
 | description | string | description of geopackage content | false
-| srid | Array<string> | srid of spatial data | true
+| crs | string | crs of spatial data, if not set source crs will be used, otherwise it will be reprojected to defined one | false
 |===
 
 .Sample json
@@ -98,7 +98,7 @@ See https://github.com/ben-lc/export-geopackage/blob/feat/add-documentation/gpkg
       },
       "geopackage": {
         "identifier": "stuff",
-        "srid": 4326,
+        "crs": "EPSG:4326",
         "description": "so much stuff"
       }
     },
@@ -110,7 +110,7 @@ See https://github.com/ben-lc/export-geopackage/blob/feat/add-documentation/gpkg
       },
       "geopackage": {
         "identifier": "another stuff",
-        "srid": 4326,
+        "crs": "EPSG:2154",
         "description": "so much other stuff"
       }
     }

--- a/src/main/kotlin/fr/benlc/exportgeopackage/DataSource.kt
+++ b/src/main/kotlin/fr/benlc/exportgeopackage/DataSource.kt
@@ -6,6 +6,7 @@ import org.geotools.data.Query
 import org.geotools.data.simple.SimpleFeatureCollection
 import org.geotools.filter.text.cql2.CQL
 import org.geotools.geopkg.FeatureEntry
+import org.geotools.referencing.CRS
 import org.opengis.filter.Filter
 
 class DataSource(config: ExportConfig) {
@@ -37,6 +38,11 @@ class DataSource(config: ExportConfig) {
         val properties = it.source.columns?.toTypedArray() ?: Query.ALL_NAMES
         val maxFeatures = it.source.maxFeatures ?: Query.DEFAULT_MAX
         val query = Query(it.source.tableName, filter, maxFeatures, properties, null)
+
+        if (!it.geopackage.crs.isNullOrBlank()) {
+          query.coordinateSystemReproject = CRS.decode(it.geopackage.crs)
+        }
+
         val features = source.getFeatures(query)
         fixAttributeNativeTypes(features.schema)
         Pair(buildFeatureEntry(it.geopackage), features)

--- a/src/main/kotlin/fr/benlc/exportgeopackage/ExportConfig.kt
+++ b/src/main/kotlin/fr/benlc/exportgeopackage/ExportConfig.kt
@@ -51,7 +51,7 @@ data class ExportConfig(val datasource: DatasourceConfig, val contents: Set<Cont
   @Serializable
   data class GeopackageConfig(
       val identifier: String? = null,
-      val srid: Int,
+      val crs: String? = null,
       val description: String? = null
   )
 }

--- a/src/main/kotlin/fr/benlc/exportgeopackage/GeopackageUtils.kt
+++ b/src/main/kotlin/fr/benlc/exportgeopackage/GeopackageUtils.kt
@@ -25,7 +25,6 @@ fun buildFeatureEntry(geopkgConfig: ExportConfig.GeopackageConfig) =
       dataType = Entry.DataType.Feature
       description = geopkgConfig.description
       identifier = geopkgConfig.identifier
-      srid = geopkgConfig.srid
     }
 
 /**

--- a/src/test/kotlin/fr/benlc/exportgeopackage/ExportConfigTest.kt
+++ b/src/test/kotlin/fr/benlc/exportgeopackage/ExportConfigTest.kt
@@ -30,7 +30,7 @@ class ExportConfigTest {
                   },
                   "geopackage": {
                     "identifier": "42",
-                    "srid": 3615,
+                    "crs": "EPSG:3615",
                     "description": "some great data"
                   }
                 },
@@ -42,7 +42,7 @@ class ExportConfigTest {
                   },
                   "geopackage": {
                     "identifier": "xzf",
-                    "srid": 3617,
+                    "crs": "EPSG:3617",
                     "description": "another great table"
                   }
                 }
@@ -58,10 +58,10 @@ class ExportConfigTest {
             setOf(
                 ExportConfig.ContentConfig(
                     ExportConfig.SourceConfig("first_table", setOf("col1", "col2"), "col1='toto'"),
-                    ExportConfig.GeopackageConfig("42", 3615, "some great data")),
+                    ExportConfig.GeopackageConfig("42", "EPSG:3615", "some great data")),
                 ExportConfig.ContentConfig(
                     ExportConfig.SourceConfig("second_table", setOf("cola", "colb"), "cola='bar'"),
-                    ExportConfig.GeopackageConfig("xzf", 3617, "another great table"))))
+                    ExportConfig.GeopackageConfig("xzf", "EPSG:3617", "another great table"))))
 
     assertEquals(expected, Json.decodeFromString(configJson))
   }

--- a/src/test/kotlin/fr/benlc/exportgeopackage/GpkgPostgresqlTest.kt
+++ b/src/test/kotlin/fr/benlc/exportgeopackage/GpkgPostgresqlTest.kt
@@ -56,7 +56,7 @@ class GpkgPostgresqlTest {
                             setOf("first_table_id", "name", "some_bigint", "some_numeric", "geom"),
                         filter = "first_table_id = 2"),
                     ExportConfig.GeopackageConfig(
-                        description = "some great data", identifier = "42", srid = 4326)),
+                        description = "some great data", identifier = "42", crs = "EPSG:2154")),
                 ExportConfig.ContentConfig(
                     ExportConfig.SourceConfig(
                         tableName = "second_table",
@@ -64,7 +64,7 @@ class GpkgPostgresqlTest {
                     ExportConfig.GeopackageConfig(
                         description = "another great table",
                         identifier = "rincevant",
-                        srid = 4326))))
+                        crs = "EPSG:4326"))))
 
     // replace config to set dynamic db connection data from testcontainers
     every { gpkg.config } returns config
@@ -84,7 +84,7 @@ class GpkgPostgresqlTest {
     assertEquals("geom", actualFirstFeatureEntry.geometryColumn)
     assertEquals("42", actualFirstFeatureEntry.identifier)
     assertEquals(Geometries.GEOMETRY, actualFirstFeatureEntry.geometryType)
-    assertEquals(4326, actualFirstFeatureEntry.srid)
+    assertEquals(2154, actualFirstFeatureEntry.srid)
     assertEquals("some great data", actualFirstFeatureEntry.description)
     assertEquals(Entry.DataType.Feature, actualFirstFeatureEntry.dataType)
 

--- a/src/test/kotlin/fr/benlc/exportgeopackage/PostgresqlDataSourceTest.kt
+++ b/src/test/kotlin/fr/benlc/exportgeopackage/PostgresqlDataSourceTest.kt
@@ -39,14 +39,14 @@ class PostgresqlDataSourceTest {
                 ContentConfig(
                     ExportConfig.SourceConfig(
                         tableName = "first_table", columns = setOf("name", "geom")),
-                    ExportConfig.GeopackageConfig(identifier = "toto", srid = 3615))))
+                    ExportConfig.GeopackageConfig(identifier = "toto", crs = "EPSG:2154"))))
     val actualFeatures = DataSource(config).fetchFeatures()
 
     val actualFirstFeature = actualFeatures.values.iterator().next().features().next()
 
     assertEquals("first one first table", actualFirstFeature.getAttribute("name"))
     assertEquals(
-        "POLYGON ((2.8649250704196603 46.249541520322815, 2.5362135416546447 45.45677308207745, 3.9751080142987703 45.44827211286614, 2.8649250704196603 46.249541520322815))",
+        "POLYGON ((689593.5624471236 6572194.591538024, 663752.0809851898 6484254.177736067, 776221.1733374989 6483674.291629725, 689593.5624471236 6572194.591538024))",
         actualFirstFeature.getAttribute("geom").toString())
   }
 }

--- a/src/test/kotlin/fr/benlc/exportgeopackage/picocli/ExportConfigConverterTest.kt
+++ b/src/test/kotlin/fr/benlc/exportgeopackage/picocli/ExportConfigConverterTest.kt
@@ -25,14 +25,14 @@ class ExportConfigConverterTest {
                         columns = setOf("id", "name", "geom"),
                         filter = "id = 2"),
                     ExportConfig.GeopackageConfig(
-                        description = "some great data", identifier = "42", srid = 4326)),
+                        description = "some great data", identifier = "42", crs = "EPSG:2154")),
                 ExportConfig.ContentConfig(
                     ExportConfig.SourceConfig(
                         tableName = "second_table", columns = setOf("id", "description", "geom")),
                     ExportConfig.GeopackageConfig(
                         description = "another great table",
                         identifier = "rincevant",
-                        srid = 4326))))
+                        crs = "EPSG:4326"))))
 
     val actual = ExportConfigConverter().convert("src/test/resources/input/config1.json")
 

--- a/src/test/resources/input/config1.json
+++ b/src/test/resources/input/config1.json
@@ -16,7 +16,7 @@
       },
       "geopackage": {
         "identifier": "42",
-        "srid": 4326,
+        "crs": "EPSG:2154",
         "description": "some great data"
       }
     },
@@ -27,7 +27,7 @@
       },
       "geopackage": {
         "identifier": "rincevant",
-        "srid": 4326,
+        "crs": "EPSG:4326",
         "description": "another great table"
       }
     }


### PR DESCRIPTION
needs to set coordinateSystemReproject in query in order to reproject features to desired crs, setting srid in FeatureEntry was useless Side effect is epsg is used instead of srid in api/